### PR TITLE
Display an error message if not providing a URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tailosinc/grafanaplugin-map-panel",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tailosinc/grafanaplugin-map-panel",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailosinc/grafanaplugin-map-panel",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Visualize maps provided by an s3 datasource",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/ImageDisplayPanel.tsx
+++ b/src/components/ImageDisplayPanel.tsx
@@ -8,19 +8,32 @@ import useMapData from './GetMaps';
 
 interface Props extends PanelProps<SimpleOptions> { }
 
+const isValidUrl = (url: string) => /^(http|https):\/\/[^ "]+$/.test(url);
+
 export const ImageDisplayPanel: React.FC<Props> = ({
   options, data, width, height,
 }) => {
   const styles = getStyles();
 
   // TODO: we'll need get all values from the first data series into URLS to be displayed
-  // First query from the S3 Data Source plugin to get the image to be displayed
+  // First series will get the image to be displayed  
   const displayUrl = data.series[0].fields[0].values.get(0);
-  // Second query from the S3 Data Source plugin to get a distinct download URL (if it exists)
+
+  // Second series will get a distinct download URL (if it exists)
   const downloadUrl = data.series.length > 1 ? data.series[1].fields[0].values.get(0) : displayUrl;
 
   const { states } = useMapData(displayUrl, width, height, options);
   const [displayDownload, setDisplayDownload] = useState(false);
+
+  if (!isValidUrl(displayUrl) || !isValidUrl(downloadUrl)) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.wrapper}>
+          ERROR: Data source must return a valid image URL, like `https://grafana.com/media/images/logos/grafana-logo-footer.svg`
+        </div>
+      </div>
+    );
+  }
 
   const { imgWidth, imgHeight } = states;
   const displayWidth = imgWidth;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -17,7 +17,7 @@
     },
     "links": [],
     "screenshots": [],
-    "version": "1.0.1",
+    "version": "1.0.4",
     "updated": "2023-07-25"
   },
   "dependencies": {


### PR DESCRIPTION
Updating based on the following feedback:

```
# Map Panel feedback

Hi and thank you for contributing to Grafana! 

I've reviewed your plugin and have the following comments: 

Required changes: 
- The zip archive you have provided contains a copy of your source code and not a built version of your plugin. Please provide a new zip archive containing the output placed in the `dist` folder after running `yarn build`. 

Suggested changes: 
- To make this panel a bit easier to discover and use it would probably be good to have some code that could detect if the provided data has the expected data structure. If the data is in an unsupported format you could display an message to the user about what data formats are supported. 

Please have a look at above comments and re-submit your plugin! 

Best regards, Marcus
```