### PR TITLE
[CD-326] Simply use the HTML5 video tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tailosinc/grafanaplugin-map-panel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tailosinc/grafanaplugin-map-panel",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@grafana/ui": "9.5.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-player": "2.13.0",
         "tslib": "2.5.3"
       },
       "devDependencies": {
@@ -8949,6 +8948,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15006,11 +15006,6 @@
       "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
       "dev": true
     },
-    "node_modules/load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -17487,26 +17482,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "node_modules/react-player": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.13.0.tgz",
-      "integrity": "sha512-gkY7ZdbVFztlKFFhCPcnDrFQm+L399b8fhWsKatZ+b2wpKJwfUHBXQFMRxqYQGT0ic1/wQ7D7EZEWy7ZBqk2pw==",
-      "dependencies": {
-        "deepmerge": "^4.0.0",
-        "load-script": "^1.0.0",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/react-player/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/react-popper": {
       "version": "2.3.0",
@@ -27656,7 +27631,8 @@
     "deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.2.0",
@@ -32200,11 +32176,6 @@
       "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
       "dev": true
     },
-    "load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
-    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -34077,25 +34048,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-player": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.13.0.tgz",
-      "integrity": "sha512-gkY7ZdbVFztlKFFhCPcnDrFQm+L399b8fhWsKatZ+b2wpKJwfUHBXQFMRxqYQGT0ic1/wQ7D7EZEWy7ZBqk2pw==",
-      "requires": {
-        "deepmerge": "^4.0.0",
-        "load-script": "^1.0.0",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.0.1"
-      },
-      "dependencies": {
-        "memoize-one": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-        }
-      }
     },
     "react-popper": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@grafana/ui": "9.5.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-player": "2.13.0",
     "tslib": "2.5.3"
   },
   "packageManager": "npm@8.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailosinc/grafanaplugin-map-panel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Visualize image files for indoor maps.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/VideoDisplayPanel.tsx
+++ b/src/components/VideoDisplayPanel.tsx
@@ -1,6 +1,5 @@
 import { stylesFactory } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
-import ReactPlayer from 'react-player'
 import React from 'react';
 
 
@@ -26,17 +25,14 @@ export const VideoDisplayPanel: React.FC<Props> = ({
 
   return (
     <>
-      <ReactPlayer 
-        url={videoUrl} 
+      <video controls 
+        src={videoUrl} 
         width={width}
         height={height}
-        light={imageUrl}
+        poster={imageUrl}
         loop={false}
-        volume={0}
         muted={true}
-        playing={true}
-        previewTabIndex={20}
-        controls={true}
+        preload='auto'
         onError={(e) => console.log('Error playing video', e)}
         className={cx(
           css`

--- a/src/components/VideoDisplayPanel.tsx
+++ b/src/components/VideoDisplayPanel.tsx
@@ -25,8 +25,9 @@ export const VideoDisplayPanel: React.FC<Props> = ({
 
   return (
     <>
-      <video controls 
+      <video 
         src={videoUrl} 
+        controls={true}
         width={width}
         height={height}
         poster={imageUrl}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -21,7 +21,7 @@
       "name": "Indoor Map screenshot", "path": "img/screenshot.png"
       }
   ],
-    "version": "1.2.0",
+    "version": "1.2.1",
     "updated": "2023-07-25"
   },
   "dependencies": {


### PR DESCRIPTION
#7 Introduced `react-player` but release validatation failed:

```
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading github.com/kevinburke/ssh_config v1.2.0
go: downloading github.com/skeema/knownhosts v1.2.1
go: downloading github.com/xanzy/ssh-agent v0.3.3
go: downloading github.com/rivo/uniseg v0.4.4
go: downloading golang.org/x/tools v0.15.0
~/work/grafanaplugin-map-panel/grafanaplugin-map-panel
error: module.js: should not include tracking scripts
detail: Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: embed.ly
Error: Process completed with exit code 1.
```

Decided to keep it simple and go with the minimal [video tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) instead.